### PR TITLE
AudioPlayer backend changes

### DIFF
--- a/SimpleTriggers/Configuration.cs
+++ b/SimpleTriggers/Configuration.cs
@@ -30,6 +30,8 @@ public class Configuration : IPluginConfiguration
     public int Version { get; set; } = 0;
     public bool EnableTriggers = true;
     public uint MaxLogHistory = 500;
+    public string AudioOutputDevice = "";
+    public bool AllowAudioBoost = false; // Lets the user boost the volume above a normally safe amount
     public TextToSpeechType TTSProvider = TextToSpeechType.None;
     public KokoroConfig Kokoro { get; set; } = new();
     public WinSpeechConfig WinSpeech { get; set; } = new();

--- a/SimpleTriggers/Plugin.cs
+++ b/SimpleTriggers/Plugin.cs
@@ -27,11 +27,10 @@ public sealed class Plugin : IDalamudPlugin
     internal uint MaxLogHistoryCeiling = 10000; // Hard coded limit. Who says? Me says.
     internal bool doLogChatHistory = false; // transient value, must be enabled by the user
     public Configuration Configuration { get; init; }
-
     public readonly WindowSystem WindowSystem = new("Simple Triggers");
     private MainWindow MainWindow { get; init; }
     private ChatListener ChatListener { get; init; }
-    private ITextToSpeech? TextToSpeech {get; set;}
+    private ITextToSpeech? TextToSpeech { get; set; }
     internal Queue<string> ChatLog { get; init; }
     
     public Plugin()
@@ -41,11 +40,9 @@ public sealed class Plugin : IDalamudPlugin
         if(Configuration.MaxLogHistory > MaxLogHistoryCeiling) { Configuration.MaxLogHistory = MaxLogHistoryCeiling; }
         ChatListener = new ChatListener(this, ChatGui);
         ChatLog = new Queue<string>((int)MaxLogHistoryCeiling);
+        SwapTTSBackend();
 
-        SwapTTSBackend(Configuration.TTSProvider);
-        var version = GetInformationalVersion();
-
-        MainWindow = new MainWindow(this, version);
+        MainWindow = new MainWindow(this, GetInformationalVersion());
         WindowSystem.AddWindow(MainWindow);
 
         CommandManager.AddHandler(CommandPrefixA, new CommandInfo(OnCommand)
@@ -131,7 +128,7 @@ public sealed class Plugin : IDalamudPlugin
         SpeakTTS(args);
     }
 
-    internal void SwapTTSBackend(TextToSpeechType ttst)
+    internal void SwapTTSBackend()
     {
         TextToSpeech?.Dispose();
         TextToSpeech = null;
@@ -140,12 +137,14 @@ public sealed class Plugin : IDalamudPlugin
         {
             case TextToSpeechType.Kokoro:
                 TextToSpeech = new STKokoro(PluginInterface.AssemblyLocation.Directory?.FullName!, PluginInterface.GetPluginConfigDirectory());
+                TextToSpeech.AudioPlayer.SetOutputDevice(Configuration.AudioOutputDevice);
                 TextToSpeech.SetVoice(KokoroVoiceHelper.ToString(Configuration.Kokoro.Voice));
                 TextToSpeech.SetSpeed(Configuration.Kokoro.Speed);
                 TextToSpeech.SetVolume(Configuration.Kokoro.Volume);
                 break;
             case TextToSpeechType.WindowsSystem:
                 TextToSpeech = new STWinSpeech();
+                TextToSpeech.AudioPlayer.SetOutputDevice(Configuration.AudioOutputDevice);
                 TextToSpeech.SetVoice(Configuration.WinSpeech.Voice);
                 TextToSpeech.SetSpeed(Configuration.WinSpeech.Speed);
                 TextToSpeech.SetVolume(Configuration.WinSpeech.Volume);
@@ -164,13 +163,6 @@ public sealed class Plugin : IDalamudPlugin
         {
             switch (Configuration.TTSProvider)
             {
-                /* case TextToSpeechType.eSpeakNG:
-                    Task.Run(() => Process.Start("/usr/bin/espeak-ng",$"\"{message}\""));
-                    break;
-                case TextToSpeechType.flite:
-                    Task.Run(() => Process.Start("/usr/bin/flite", $"-t \"{message}\""));
-                    break;
-                */
                 case TextToSpeechType.Kokoro:
                     Task.Run(() => TextToSpeech?.Speak(message, Configuration.Kokoro.UseEspeak));
                     break;
@@ -183,6 +175,7 @@ public sealed class Plugin : IDalamudPlugin
         }
     }
 
+    internal void SetTTSOutputDevice(int id) => TextToSpeech?.AudioPlayer.SetOutputDevice(id);
     internal void SetTTSVoice(string voice) => TextToSpeech?.SetVoice(voice);
     internal void SetTTSVolume(float volume) => TextToSpeech?.SetVolume(volume);
     internal void SetTTSSpeed(float speed) => TextToSpeech?.SetSpeed(speed);

--- a/SimpleTriggers/Plugin.cs
+++ b/SimpleTriggers/Plugin.cs
@@ -27,6 +27,7 @@ public sealed class Plugin : IDalamudPlugin
     internal uint MaxLogHistoryCeiling = 10000; // Hard coded limit. Who says? Me says.
     internal bool doLogChatHistory = false; // transient value, must be enabled by the user
     public Configuration Configuration { get; init; }
+    
     public readonly WindowSystem WindowSystem = new("Simple Triggers");
     private MainWindow MainWindow { get; init; }
     private ChatListener ChatListener { get; init; }

--- a/SimpleTriggers/SimpleTriggers.csproj
+++ b/SimpleTriggers/SimpleTriggers.csproj
@@ -1,8 +1,8 @@
 ﻿
 <Project Sdk="Dalamud.NET.Sdk/14.0.2">
   <PropertyGroup>
-    <Version>0.3.3.0</Version>
-    <InformationalVersion>0.3.3.0-outputdevice</InformationalVersion>
+    <Version>0.3.3.1</Version>
+    <InformationalVersion>0.3.3.1-audiobackend</InformationalVersion>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <PackageProjectUrl>https://github.com/Brolijah/SimpleTriggers</PackageProjectUrl>
     <PackageLicenseExpression>AGPL-3.0-or-later</PackageLicenseExpression>

--- a/SimpleTriggers/SimpleTriggers.csproj
+++ b/SimpleTriggers/SimpleTriggers.csproj
@@ -1,8 +1,8 @@
 ﻿
 <Project Sdk="Dalamud.NET.Sdk/14.0.2">
   <PropertyGroup>
-    <Version>0.3.2.0</Version>
-    <InformationalVersion>0.3.2.0</InformationalVersion>
+    <Version>0.3.3.0</Version>
+    <InformationalVersion>0.3.3.0-outputdevice</InformationalVersion>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <PackageProjectUrl>https://github.com/Brolijah/SimpleTriggers</PackageProjectUrl>
     <PackageLicenseExpression>AGPL-3.0-or-later</PackageLicenseExpression>

--- a/SimpleTriggers/TextToSpeech/AudioPlayer.cs
+++ b/SimpleTriggers/TextToSpeech/AudioPlayer.cs
@@ -29,8 +29,7 @@ public class AudioPlayer : IDisposable
                     await semaphore.WaitAsync();
                     try {
                         var stream = new RawSourceWaveStream(packet, 0, packet.Length, waveFormat);
-                        var mix = new VolumeSampleProvider(stream.ToSampleProvider());
-                        mix.Volume = volume;
+                        var mix = new VolumeSampleProvider(stream.ToSampleProvider()) { Volume = volume };
                         waveOut.Init(mix);
                         waveOut.Play();
                         while(!hasExited && waveOut.PlaybackState == PlaybackState.Playing) { await Task.Delay(5); }
@@ -77,7 +76,7 @@ public class AudioPlayer : IDisposable
         }
     }
 
-    // volume = [0.0f, 100.0f] // technically allows values >100, and that *might* be fine? idk
+    // volume = [0.0f, 100.0f] // technically allows values >100, and that *might* be fine?
     public void SetVolume(float volume)
     {
         this.volume = volume/100f;

--- a/SimpleTriggers/TextToSpeech/AudioPlayer.cs
+++ b/SimpleTriggers/TextToSpeech/AudioPlayer.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using NAudio.CoreAudioApi;
+using NAudio.Wave;
+using NAudio.Wave.SampleProviders;
+
+namespace SimpleTriggers.TextToSpeech;
+
+public class AudioPlayer : IDisposable
+{
+    private readonly SemaphoreSlim semaphore = new(1, 1);
+    private readonly WaveFormat waveFormat = new (24000, 16, 1);
+    private readonly ConcurrentQueue<byte[]> queue = [];
+    private WaveOutEvent waveOut;
+    volatile float volume = 1.0f;
+    volatile bool hasExited = false;
+
+    public AudioPlayer(string deviceId = "")
+    {
+        waveOut = new WaveOutEvent() { DeviceNumber = DeviceIdToNumber(deviceId) };
+        new Thread(async() => {
+            while(!hasExited) {
+                await Task.Delay(50);
+                // check queue
+                while(!hasExited && queue.TryDequeue(out var packet))
+                {
+                    await semaphore.WaitAsync();
+                    try {
+                        var stream = new RawSourceWaveStream(packet, 0, packet.Length, waveFormat);
+                        var mix = new VolumeSampleProvider(stream.ToSampleProvider());
+                        mix.Volume = volume;
+                        waveOut.Init(mix);
+                        waveOut.Play();
+                        while(!hasExited && waveOut.PlaybackState == PlaybackState.Playing) { await Task.Delay(5); }
+                        if(!hasExited) { waveOut.Stop(); }
+                    } finally { semaphore.Release(); }
+                }
+            }
+        }){ IsBackground = true }.Start();
+    }
+
+    private int DeviceIdToNumber(string id)
+    {
+        var enumerator = new MMDeviceEnumerator();
+        var devices = enumerator.EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active);
+        for(int i = 0; i < devices.Count-1; ++i)
+        {
+            if(devices[i].ID.Equals(id)) return i;
+        }
+        return -1;
+    }
+
+    public void SetOutputDevice(int deviceId = 0)
+    {
+        semaphore.WaitAsync();
+        try
+        {
+            waveOut.Stop();
+            waveOut.Dispose();
+            waveOut = new WaveOutEvent() { DeviceNumber = deviceId };
+        } finally { semaphore.Release(); }
+    }
+
+    public void SetOutputDevice(string deviceId)
+    {
+        SetOutputDevice(DeviceIdToNumber(deviceId));
+    }
+    
+    public void StopPlayback(bool clearQueue = false)
+    {
+        waveOut.Stop();
+        if(clearQueue)
+        {
+            queue.Clear();
+        }
+    }
+
+    // volume = [0.0f, 100.0f] // technically allows values >100, and that *might* be fine? idk
+    public void SetVolume(float volume)
+    {
+        this.volume = volume/100f;
+    }
+
+    public void Dispose()
+    {
+        hasExited = true;
+        waveOut.Stop();
+        waveOut.Dispose();
+        queue.Clear();
+    }
+
+    public void Enqueue(byte[] stream)
+    {
+        ObjectDisposedException.ThrowIf(hasExited, this);
+        queue.Enqueue(stream);
+    }
+    
+}

--- a/SimpleTriggers/TextToSpeech/ITextToSpeech.cs
+++ b/SimpleTriggers/TextToSpeech/ITextToSpeech.cs
@@ -1,5 +1,6 @@
 
 using System;
+using SimpleTriggers.TextToSpeech;
 
 public interface ITextToSpeech : IDisposable
 {
@@ -9,4 +10,5 @@ public interface ITextToSpeech : IDisposable
     void SetSpeed(float speed);
     void SetLanguage(string lang);
     bool IsInitialized();
+    AudioPlayer AudioPlayer { get; }
 }

--- a/SimpleTriggers/TextToSpeech/STKokoro.cs
+++ b/SimpleTriggers/TextToSpeech/STKokoro.cs
@@ -18,30 +18,29 @@ public class STKokoro : ITextToSpeech
     // sha256 = c1610a859f3bdea01107e73e50100685af38fff88f5cd8e5c56df109ec880204
     private const string ModelUri = "https://github.com/taylorchu/kokoro-onnx/releases/download/v0.2.0/kokoro-quant.onnx";
     private readonly string configPath;
-    private readonly Task<KokoroTTS?> ttsTask;
+    private readonly Task<KokoroModel?> modelTask;
     private readonly Task<IPA?> ipaTask;
     private readonly CancellationTokenSource cts = new();
     private float speed = 1.0f;
     private string lang = "en-us";
     private KokoroVoice kv;
-    private KokoroPlayback kp;
-    private KokoroJob? lastJob;
+    public AudioPlayer AudioPlayer { get; }
     public STKokoro(string binPath, string configPath)
     {
         this.configPath = configPath;
-        ttsTask = LoadModelAsync();
-        ipaTask = LoadDictionaryAsync(binPath);     
+        modelTask = LoadModelAsync();
+        ipaTask = LoadDictionaryAsync(Path.Join(binPath, "en_US.txt"));     
         Tokenizer.eSpeakNGPath = Path.Join(binPath, "espeak");
         KokoroVoiceManager.LoadVoicesFromPath(Path.Join(binPath,"voices"));
         kv = KokoroVoiceManager.GetVoice("af_bella");
-        kp = new KokoroPlayback();
+        AudioPlayer = new AudioPlayer();
     }
 
     private async Task<IPA?> LoadDictionaryAsync(string path)
     {
         try
         {
-            return new IPA(Path.Join(path, "en_US.txt"));
+            return new IPA(path);
         } catch (Exception e)
         {
             STLog.Log.Error(e, "STKokoro.LoadDictionaryAsync(): Exception caught:");
@@ -49,7 +48,7 @@ public class STKokoro : ITextToSpeech
         }
     }
 
-    private async Task<KokoroTTS?> LoadModelAsync()
+    private async Task<KokoroModel?> LoadModelAsync()
     {
         bool download = false;
         var path = GetModelPath();
@@ -85,17 +84,17 @@ public class STKokoro : ITextToSpeech
             return null;
         }
 
-        return KokoroTTS.LoadModel(path);
+        return new KokoroModel(path);
     }
 
-    private bool TryGetKokoroTTS([NotNullWhen(true)] out KokoroTTS? tts)
+    private bool TryGetKokoroModel([NotNullWhen(true)] out KokoroModel? model)
     {
-        if(ttsTask.IsCompletedSuccessfully)
+        if(modelTask.IsCompletedSuccessfully)
         {
-            tts = ttsTask.Result;
-        } else { tts = null; }
+            model = modelTask.Result;
+        } else { model = null; }
 
-        return tts != null;
+        return model != null;
     }
 
     private bool TryGetIPA([NotNullWhen(true)] out IPA? ipa)
@@ -118,13 +117,11 @@ public class STKokoro : ITextToSpeech
         kv = KokoroVoiceManager.GetVoice(strVoice);
     }
 
-    // [0.0, 100.0]
     public void SetVolume(float volume)
     {
-        var v = volume/100f; // scales it down between [0, 1]
         try
         {
-            kp.SetVolume(v);
+            AudioPlayer.SetVolume(volume);
         } catch (Exception e)
         {
             STLog.Log.Warning(e,"Exception caught:");
@@ -143,7 +140,7 @@ public class STKokoro : ITextToSpeech
 
     public void Speak(string message, bool extra)
     {
-        if(TryGetKokoroTTS(out var tts) && TryGetIPA(out var ipa))
+        if(TryGetKokoroModel(out var tts) && TryGetIPA(out var ipa))
         {
             try
             {
@@ -151,9 +148,18 @@ public class STKokoro : ITextToSpeech
                 if(extra) tokens = Tokenizer.Tokenize(message, lang);
                 else      tokens = Tokenizer.TokenizePhonemes(ipa.EnglishToIPA(message).ToCharArray());
 
-                lastJob?.Cancel();
-                kp.StopPlayback();
-                lastJob = tts.EnqueueJob(KokoroJob.Create(tokens, kv, speed, kp.Enqueue));
+                AudioPlayer.StopPlayback(true);
+                var tokensList = SegmentationSystem.SplitToSegments(tokens, new()
+                {
+                    MinFirstSegmentLength = 20,
+                    MaxFirstSegmentLength = 200,
+                    MaxSecondSegmentLength = 200
+                });
+                foreach (var tc in tokensList)
+                {
+                    var bytes = KokoroPlayback.GetBytes(tts.Infer(tc, kv.Features, speed));
+                    AudioPlayer.Enqueue(bytes);
+                }
             } catch (Exception e)
             {
                 STLog.Log.Error(e, "STKokoro.Speak(): Exception caught: ");
@@ -165,20 +171,20 @@ public class STKokoro : ITextToSpeech
 
     public bool IsInitialized()
     {
-        return TryGetKokoroTTS(out _) && TryGetIPA(out _);
+        return TryGetKokoroModel(out _) && TryGetIPA(out _);
     }
 
     public void Dispose()
     {
         cts.Cancel();
-        kp.Dispose();
+        AudioPlayer.Dispose();
         if(TryGetIPA(out var ipa))
         {
             ipa.Dispose();
         }
-        if(TryGetKokoroTTS(out var tts))
+        if(TryGetKokoroModel(out var model))
         {
-            tts.Dispose();
+            model.Dispose();
         }
     }
 }

--- a/SimpleTriggers/TextToSpeech/STKokoro.cs
+++ b/SimpleTriggers/TextToSpeech/STKokoro.cs
@@ -119,13 +119,7 @@ public class STKokoro : ITextToSpeech
 
     public void SetVolume(float volume)
     {
-        try
-        {
-            AudioPlayer.SetVolume(volume);
-        } catch (Exception e)
-        {
-            STLog.Log.Warning(e,"Exception caught:");
-        }
+        AudioPlayer.SetVolume(volume);
     }
 
     public void SetSpeed(float speed)
@@ -140,15 +134,15 @@ public class STKokoro : ITextToSpeech
 
     public void Speak(string message, bool extra)
     {
-        if(TryGetKokoroModel(out var tts) && TryGetIPA(out var ipa))
+        if(TryGetKokoroModel(out var model) && TryGetIPA(out var ipa))
         {
+            AudioPlayer.StopPlayback(true);
             try
             {
                 int[]? tokens;
                 if(extra) tokens = Tokenizer.Tokenize(message, lang);
                 else      tokens = Tokenizer.TokenizePhonemes(ipa.EnglishToIPA(message).ToCharArray());
 
-                AudioPlayer.StopPlayback(true);
                 var tokensList = SegmentationSystem.SplitToSegments(tokens, new()
                 {
                     MinFirstSegmentLength = 20,
@@ -157,7 +151,7 @@ public class STKokoro : ITextToSpeech
                 });
                 foreach (var tc in tokensList)
                 {
-                    var bytes = KokoroPlayback.GetBytes(tts.Infer(tc, kv.Features, speed));
+                    var bytes = KokoroPlayback.GetBytes(model.Infer(tc, kv.Features, speed));
                     AudioPlayer.Enqueue(bytes);
                 }
             } catch (Exception e)

--- a/SimpleTriggers/TextToSpeech/STWinSpeech.cs
+++ b/SimpleTriggers/TextToSpeech/STWinSpeech.cs
@@ -1,13 +1,17 @@
 using System;
 using System.Speech.Synthesis;
 using SimpleTriggers.Logger;
+using SimpleTriggers.TextToSpeech;
 
 public class STWinSpeech : ITextToSpeech
 {
+    public AudioPlayer AudioPlayer { get; }
     private SpeechSynthesizer synth {get; init;}
     public STWinSpeech()
     {
         synth = new SpeechSynthesizer();
+        AudioPlayer = new AudioPlayer();
+        // TODO
         synth.SetOutputToDefaultAudioDevice();
     }
 
@@ -53,6 +57,7 @@ public class STWinSpeech : ITextToSpeech
 
     public void Dispose()
     {
+        AudioPlayer.Dispose();
         synth.Dispose();
     }
 }

--- a/SimpleTriggers/TextToSpeech/STWinSpeech.cs
+++ b/SimpleTriggers/TextToSpeech/STWinSpeech.cs
@@ -42,6 +42,7 @@ public class STWinSpeech : ITextToSpeech
 
     public void Speak(string message, bool extra)
     {
+        AudioPlayer.StopPlayback(true);
         try
         {
             synth.SpeakAsyncCancelAll();

--- a/SimpleTriggers/TextToSpeech/STWinSpeech.cs
+++ b/SimpleTriggers/TextToSpeech/STWinSpeech.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Speech.Synthesis;
 using SimpleTriggers.Logger;
 using SimpleTriggers.TextToSpeech;
@@ -7,12 +8,12 @@ public class STWinSpeech : ITextToSpeech
 {
     public AudioPlayer AudioPlayer { get; }
     private SpeechSynthesizer synth {get; init;}
+    private MemoryStream? stream;
     public STWinSpeech()
     {
-        synth = new SpeechSynthesizer();
         AudioPlayer = new AudioPlayer();
-        // TODO
-        synth.SetOutputToDefaultAudioDevice();
+        synth = new SpeechSynthesizer();
+        synth.SpeakCompleted += OnSpeakCompleted;
     }
 
     public void SetVoice(string voice)
@@ -28,7 +29,7 @@ public class STWinSpeech : ITextToSpeech
 
     public void SetVolume(float volume)
     {
-        synth.Volume = (int)Math.Clamp(volume, 0, 100);
+        AudioPlayer.SetVolume(volume);
     }
 
     public void SetSpeed(float speed)
@@ -43,11 +44,35 @@ public class STWinSpeech : ITextToSpeech
     {
         try
         {
+            synth.SpeakAsyncCancelAll();
+
+            stream?.Dispose();
+            stream = new MemoryStream();
+            
+            synth.SetOutputToWaveStream(stream);
             synth.SpeakAsync(message);
         } catch (Exception e)
         {
             STLog.Log.Error(e, "STWinSpeech.Speak(): Exception caught:");
         }
+    }
+
+    private void OnSpeakCompleted(object? sender, SpeakCompletedEventArgs e)
+    {
+        if(e.Error is not null)
+        {
+            STLog.Log.Error($"STWinSpeech.OnSpeakCompleted(): Error: {e.Error.Message}");
+            return;
+        }
+        if(e.Cancelled || stream == null) // don't care, abort
+        {
+            return;
+        }
+        // Queues the stream into the AudioPlayer
+        var data = new byte[stream.Length-44]; // will hold raw PCM stream without header
+        stream.Position = 44;
+        stream.Read(data, 0, data.Length);
+        AudioPlayer.Enqueue(data);
     }
 
     public bool IsInitialized()
@@ -58,6 +83,8 @@ public class STWinSpeech : ITextToSpeech
     public void Dispose()
     {
         AudioPlayer.Dispose();
+        synth.SpeakCompleted -= OnSpeakCompleted;
         synth.Dispose();
+        stream?.Dispose();
     }
 }

--- a/SimpleTriggers/Windows/MainWindow.cs
+++ b/SimpleTriggers/Windows/MainWindow.cs
@@ -411,7 +411,7 @@ public class MainWindow : Window, IDisposable
                                     state.activeCategory = category;
                                 }
 
-                                using(var pop = ImRaii.ContextPopupItem($"##RemoveTriggerPopup"))
+                                using(var pop = ImRaii.ContextPopupItem("##RemoveTriggerPopup"))
                                 {
                                     if(pop)
                                     {
@@ -436,9 +436,9 @@ public class MainWindow : Window, IDisposable
                 // Background text in the window to instruct users on creating their first triggers
                 if(idx==0)
                 {
-                    using var color = ImRaii.PushColor(ImGuiCol.Text, new Vector4(1.0f, 1.0f, 1.0f, 0.8f));
-                    ImGui.Text("Looks like you have no triggers yet. To get started, click the \"Add\" button.\n"+
-                               "Or, you can Save a chat message from the \"Chat History\" tab.");
+                    ImGui.TextColoredWrapped(new Vector4(1.0f, 1.0f, 1.0f, 0.8f),
+                        "Looks like you have no triggers yet. To get started, click the \"Add\" button.\n"+
+                        "Or, you can Save a chat message from the \"Chat History\" tab.");
                 }
             }
         }
@@ -528,10 +528,9 @@ public class MainWindow : Window, IDisposable
             ImGui.SetNextItemWidth(120 * ImGuiHelpers.GlobalScale);
             ImGui.DragScalar<uint>("Max Log History##MaxHistoryLength",
                 ref plugin.Configuration.MaxLogHistory,0.2f,0, plugin.MaxLogHistoryCeiling,default,ImGuiSliderFlags.AlwaysClamp);
-            if(plugin.Configuration.MaxLogHistory > plugin.MaxLogHistoryCeiling)
-                plugin.Configuration.MaxLogHistory = Math.Clamp(plugin.Configuration.MaxLogHistory, 1, plugin.MaxLogHistoryCeiling);
             if(ImGui.IsItemDeactivatedAfterEdit())
             {
+                plugin.Configuration.MaxLogHistory = Math.Clamp(plugin.Configuration.MaxLogHistory, 1, plugin.MaxLogHistoryCeiling);
                 plugin.Configuration.Save();
             }
 

--- a/SimpleTriggers/Windows/MainWindow.cs
+++ b/SimpleTriggers/Windows/MainWindow.cs
@@ -12,6 +12,7 @@ using SimpleTriggers.SeFunctions;
 using SimpleTriggers.TextToSpeech;
 using SimpleTriggers.Triggers;
 using SimpleTriggers.Logger;
+using NAudio.CoreAudioApi;
 
 namespace SimpleTriggers.Windows;
 
@@ -551,7 +552,7 @@ public class MainWindow : Window, IDisposable
                         {
                             plugin.Configuration.TTSProvider = (TextToSpeechType)i;
                             plugin.Configuration.Save();
-                            plugin.SwapTTSBackend((TextToSpeechType)i);
+                            plugin.SwapTTSBackend();
                         }
                     }
                 }
@@ -569,6 +570,28 @@ public class MainWindow : Window, IDisposable
                 STWinSpeechUI.DrawWinSpeechSettings(plugin);
             }
             ImGui.Unindent();
+
+            // Output Device
+            {
+                ImGui.NewLine();
+                var enumerator = new MMDeviceEnumerator();
+                var devices = enumerator.EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active);
+                ImGui.SetNextItemWidth(300 * ImGuiHelpers.GlobalScale);
+                using (var box = ImRaii.Combo("Output Device", devices.FirstOrDefault(d => d.ID == plugin.Configuration.AudioOutputDevice)?.FriendlyName ?? devices.First().FriendlyName))
+                {
+                    if (box)
+                    {
+                        for(var i = 0; i < devices.Count-1; ++i)
+                        {
+                            if(ImGui.Selectable($"{devices[i].FriendlyName}"))
+                            {
+                                plugin.Configuration.AudioOutputDevice = devices[i].ID;
+                                plugin.SetTTSOutputDevice(i);
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/SimpleTriggers/Windows/STKokoroUI.cs
+++ b/SimpleTriggers/Windows/STKokoroUI.cs
@@ -41,7 +41,7 @@ public static class STKokoroUI
 
         // Volume and Speed
         ImGui.SetNextItemWidth(192 * ImGuiHelpers.GlobalScale);
-        ImGui.SliderFloat("Voice Speed", ref plugin.Configuration.Kokoro.Speed,0.5f, 1.5f,"%.1fx");
+        ImGui.SliderFloat("Voice Speed", ref plugin.Configuration.Kokoro.Speed,0.5f, 1.5f,"%.1fx", ImGuiSliderFlags.NoInput);
         if(ImGui.IsItemDeactivatedAfterEdit())
         {
             plugin.SetTTSSpeed(plugin.Configuration.Kokoro.Speed);
@@ -74,7 +74,7 @@ public static class STKokoroUI
         }
         ImGui.SameLine();
         ImGui.PushFont(UiBuilder.IconFont);
-        ImGui.Text($"{FontAwesomeIcon.ExclamationCircle.ToIconString()}");
+        ImGui.Text(FontAwesomeIcon.ExclamationCircle.ToIconString());
         ImGui.PopFont();
         ImGuiCustom.HoverTooltip("May result in more natural voices, \nhowever if it causes issues, leave disabled.");
 

--- a/SimpleTriggers/Windows/STKokoroUI.cs
+++ b/SimpleTriggers/Windows/STKokoroUI.cs
@@ -49,9 +49,21 @@ public static class STKokoroUI
         }
         
         ImGui.SetNextItemWidth(192 * ImGuiHelpers.GlobalScale);
-        ImGui.SliderFloat("Voice Volume", ref plugin.Configuration.Kokoro.Volume,1.0f, 100.0f,"%.0f%%");
+        if(plugin.Configuration.AllowAudioBoost) // Danger Zone, Use Wisely
+        {
+            ImGui.DragScalar<float>("Voice Volume", ref plugin.Configuration.Kokoro.Volume,1f,1f,3000f,"%.0f%%",ImGuiSliderFlags.AlwaysClamp);
+        } else { // Normal Range
+            ImGui.SliderFloat("Voice Volume", ref plugin.Configuration.Kokoro.Volume,1.0f, 200.0f,"%.0f%%", ImGuiSliderFlags.NoInput);
+        }
         if(ImGui.IsItemDeactivatedAfterEdit())
         {
+            plugin.Configuration.Kokoro.Volume = Math.Clamp(plugin.Configuration.Kokoro.Volume, 1, plugin.Configuration.AllowAudioBoost ? 3000 : 200);
+            plugin.SetTTSVolume(plugin.Configuration.Kokoro.Volume);
+            plugin.Configuration.Save();
+        }
+        if(ImGui.Checkbox("Allow boosting over 200%", ref plugin.Configuration.AllowAudioBoost))
+        {
+            plugin.Configuration.Kokoro.Volume = Math.Clamp(plugin.Configuration.Kokoro.Volume, 1, 200);
             plugin.SetTTSVolume(plugin.Configuration.Kokoro.Volume);
             plugin.Configuration.Save();
         }

--- a/SimpleTriggers/Windows/STWinSpeechUI.cs
+++ b/SimpleTriggers/Windows/STWinSpeechUI.cs
@@ -64,12 +64,23 @@ public static class STWinSpeechUI
         }
 
         ImGui.SetNextItemWidth(192 * ImGuiHelpers.GlobalScale);
-        ImGui.SliderInt("Voice Volume", ref plugin.Configuration.WinSpeech.Volume,1, 100,"%d%%");
+        if(plugin.Configuration.AllowAudioBoost) // Danger Zone, Use Wisely
+        {
+            ImGui.DragScalar("Voice Volume", ref plugin.Configuration.WinSpeech.Volume,1f,1,3000,"%d%%",ImGuiSliderFlags.AlwaysClamp);
+        } else { // Normal Range
+            ImGui.SliderInt("Voice Volume", ref plugin.Configuration.WinSpeech.Volume,1, 200,"%d%%", ImGuiSliderFlags.NoInput);
+        }
         if(ImGui.IsItemDeactivatedAfterEdit())
         {
+            plugin.Configuration.WinSpeech.Volume = Math.Clamp(plugin.Configuration.WinSpeech.Volume, 1, plugin.Configuration.AllowAudioBoost ? 3000 : 200);
+            plugin.SetTTSVolume(plugin.Configuration.WinSpeech.Volume);
+            plugin.Configuration.Save();
+        }
+        if(ImGui.Checkbox("Allow boosting over 200%", ref plugin.Configuration.AllowAudioBoost))
+        {
+            plugin.Configuration.WinSpeech.Volume = Math.Clamp(plugin.Configuration.WinSpeech.Volume, 1, 200);
             plugin.SetTTSVolume(plugin.Configuration.WinSpeech.Volume);
             plugin.Configuration.Save();
         }
     }
-
 }

--- a/SimpleTriggers/Windows/STWinSpeechUI.cs
+++ b/SimpleTriggers/Windows/STWinSpeechUI.cs
@@ -56,7 +56,7 @@ public static class STWinSpeechUI
 
         // Volume and Speed
         ImGui.SetNextItemWidth(192 * ImGuiHelpers.GlobalScale);
-        ImGui.SliderInt("Voice Speed", ref plugin.Configuration.WinSpeech.Speed,-5, 5, "%+d");
+        ImGui.SliderInt("Voice Speed", ref plugin.Configuration.WinSpeech.Speed,-5, 5, "%+d", ImGuiSliderFlags.NoInput);
         if(ImGui.IsItemDeactivatedAfterEdit())
         {
             plugin.SetTTSSpeed(plugin.Configuration.WinSpeech.Speed);


### PR DESCRIPTION
v0.3.3.1 which includes the following changes:
* TTS audio playback is now handled by an AudioPlayer class. Both Kokoro and WinSpeech feed into this.
* You can now specify the output device in the Settings tab. Keep in mind it'll still show as the game in your OS's volume mixer.
* Volume is now more customizable, allowing values above 100%. For safety, the dial by default only goes up to 200%, but there's a checkbox directly under the volume setting which will allow you to go up to 3000% if you *really* feel like you need it. Since TTS volume is tied to the game's volume in your OS audio settings, this might give you the boost you need if you keep the game volume really, really low.
* Tested with Kokoro in Linux. Windows Speech should be working. But needs more testers.